### PR TITLE
Changes way bot handles images without text

### DIFF
--- a/3dm.py
+++ b/3dm.py
@@ -106,8 +106,12 @@ async def checkImgPost(msg):
                 check = re.search('(http[^ ]+(:?jpg|png|jpeg))', post_url.lower())
                 if check and not 'unknown.png' in post_url.lower():
                     post_link = 'https://discordapp.com/channels/{2}/{0}/{1}'.format( msg.channel.id, msg.id, SERVER_ID )
-                    out_emb = discord.Embed(title="New image from: {0}".format(msg.author.display_name),
-                                            description="Sent in <#{0}> - _[original post]({2})_\n\n>>> `{1}`".format(msg.channel.id, msg.content, post_link), color=0xffffff)
+                    if msg.content:
+                        out_emb = discord.Embed(title="New image from: {0}".format(msg.author.display_name),
+                                                description="Sent in <#{0}> - _[original post]({2})_\n\n>>> `{1}`".format(msg.channel.id, msg.content, post_link), color=0xffffff)
+                    else:
+                        out_emb = discord.Embed(title="New image from: {0}".format(msg.author.display_name),
+                                                description="Sent in <#{0}> - _[original post]({1})_\n\n>>> Message has no content.".format(msg.channel.id, post_link), color=0xffffff)
                     try:
                         out_emb.set_thumbnail(url=post_url)
                     except:


### PR DESCRIPTION
Normally in #3dm-bot-img whenever the bot finds an image with no text it will try to put it in a code block, but since there is no message it will just post 2 backticks, which may look weird/confusing. This will essentially just make the bot say "Message has no content." (not in a code block so as to not confuse it with the actual message they sent) in the case that they do not have any text in their message.